### PR TITLE
fixed cloudshell-automation-api version requirements

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -1,4 +1,4 @@
-cloudshell-automation-api>=7.0.0.0,<7.1.0.0
+cloudshell-automation-api>=7.1.0.0,<7.2.0.0
 cloudshell-core>=2.1.0,<2.2.0
 cloudshell-shell-core>=2.2.0,<2.3.0
 python-novaclient>=4.0.8,<5.1.0


### PR DESCRIPTION
Changed requirements version for cloudshell-automation-api to 7.1<=x<7.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/54)
<!-- Reviewable:end -->
