### PR TITLE
#79 Fix

### DIFF
--- a/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
@@ -31,11 +31,14 @@ class NeutronNetworkService(object):
         network_type = cp_resource_model.vlan_type.lower()
 
         nw_name = "net_segmentation_id_{0}".format(segmentation_id)
-        create_nw_json = {'provider:physical_network': interface_name,
-                              'provider:network_type': network_type,
+        create_nw_json = {'provider:network_type': network_type,
                               'provider:segmentation_id': segmentation_id,
                               'name': nw_name,
                               'admin_state_up': True}
+
+        if network_type == 'vlan':
+            create_nw_json.update({'provider:physical_network': interface_name})
+
         try:
             new_net = client.create_network({'network': create_nw_json})
             new_net = new_net['network']


### PR DESCRIPTION
If the network type is vlan only then "provider:physical_network" parameter is required. Not required for vxlan.

## Description

OpenStack-Shell now works with both VLAN and VxLAN. 

## Related Stories

#77 

## Breaking
 NO

## Breaking changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/91)
<!-- Reviewable:end -->
