### PR TITLE
 #106 Fix removed the references to security group from the code

### DIFF
--- a/package/cloudshell/cp/openstack/models/model_parser.py
+++ b/package/cloudshell/cp/openstack/models/model_parser.py
@@ -28,7 +28,6 @@ class OpenStackShellModelParser(object):
         os_res_model.vlan_type = attrs['Vlan Type']
         os_res_model.provider_network_interface = attrs['Provider Network Interface']
         os_res_model.external_network_uuid = attrs['External Network UUID']
-        os_res_model.default_sec_group_uuid = attrs['Default Security Group UUID']
         return os_res_model
 
     @staticmethod

--- a/package/cloudshell/cp/openstack/models/openstack_resource_model.py
+++ b/package/cloudshell/cp/openstack/models/openstack_resource_model.py
@@ -14,7 +14,6 @@ class OpenStackResourceModel:
         self.vlan_type = ''
         self.provider_network_interface = ''
         self.external_network_uuid = ''
-        self.default_sec_group_uuid = ''
 
     def __str__(self):
         desc = "OpenStack Resource: controller_url: {0}, domain: {1}, project_name : {2}, os_user_name : {3}".format(

--- a/package/tests/test_cp/test_openstack/test_models/test_model_parser.py
+++ b/package/tests/test_cp/test_openstack/test_models/test_model_parser.py
@@ -25,7 +25,6 @@ class TestOpenStackShellModelParser(TestCase):
         test_resource.attributes['Vlan Type'] = 'vlan'
         test_resource.attributes['Provider Network Interface'] = 'public'
         test_resource.attributes['External Network UUID'] = 'external_network_uuid'
-        test_resource.attributes['Default Security Group UUID'] = 'default_secgroup_uuid'
         result = self.tested_class.get_resource_model_from_context(test_resource)
 
         self.assertEqual(result.controller_url, 'test url')
@@ -39,8 +38,7 @@ class TestOpenStackShellModelParser(TestCase):
         self.assertEqual(result.vlan_type, 'vlan')
         self.assertEqual(result.provider_network_interface, 'public')
         self.assertEqual(result.external_network_uuid, 'external_network_uuid')
-        self.assertEqual(result.default_sec_group_uuid, 'default_secgroup_uuid')
-
+        
     @mock.patch("cloudshell.cp.openstack.models.model_parser.jsonpickle")
     @mock.patch("cloudshell.cp.openstack.models.model_parser.DeployOSNovaImageInstanceResourceModel")
     @mock.patch("cloudshell.cp.openstack.models.model_parser.DeployDataHolder")


### PR DESCRIPTION
 The datamodel didn't refer to default security group, but the code was
 refering

## Description
Fixex #106 

## Related Stories
 #17 

## Breaking
 NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/107)
<!-- Reviewable:end -->
