### PR TITLE
 #95 fix. All error messages are now reported to user correctly

### DIFF
--- a/package/cloudshell/cp/openstack/domain/services/connectivity/vlan_connectivity_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/connectivity/vlan_connectivity_service.py
@@ -88,6 +88,16 @@ class VLANConnectivityService(object):
 
         return driver_response_root
 
+    def _format_err_msg_for_exception(self, e):
+        """
+
+        :param Exception e:
+        :return:
+        """
+        err_msg = "{0} {1}".format(type(e), e.message)
+        err_msg = err_msg.replace("<", "(").replace(">", ")")
+        return err_msg
+
     def set_vlan_actions(self, openstack_session, cp_resource_model, vlan_actions, logger):
         """
 
@@ -111,8 +121,7 @@ class VLANConnectivityService(object):
                                                                                   logger=logger)
             except Exception as e:
                 logger.error(traceback.format_exc())
-                net_err_msg = "{0} {1}".format(type(e), e.message)
-                net_err_msg = net_err_msg.replace("<", "(").replace(">", ")")
+                net_err_msg = self._format_err_msg_for_exception(e)
             if not net:
                 fail_results = self.set_fail_results(values=values,
                                                       action_type='setVlan',
@@ -136,8 +145,7 @@ class VLANConnectivityService(object):
                         subnet = subnet[0]
                 except Exception as e:
                     logger.error(traceback.format_exc())
-                    subnet_err_msg = "{0} {1}".format(type(e), e.message)
-                    subnet_err_msg = subnet_err_msg.replace("<", "(").replace(">", ")")
+                    subnet_err_msg = self._format_err_msg_for_exception(e)
                 if not subnet:
                     fail_results = self.set_fail_results(values=values,
                                                           action_type='setVlan',
@@ -289,16 +297,15 @@ class VLANConnectivityService(object):
             result = self.instance_service.attach_nic_to_net(openstack_session=openstack_session,
                                                              instance_id=instance_id, net_id=net_id, logger=logger)
         except Exception as e:
-            result_err_msg = "{0} {1}".format(type(e), e.message)
-            result_err_msg = result_err_msg.replace("<", "(").replace(">",")")
+            result_err_msg = self._format_err_msg_for_exception(e)
             logger.error(result_err_msg)
         if not result:
             action_result.success = "False"
             action_result.actionId = action_resource_info.actionid
             action_result.errorMessage = "Failed to Attach NIC on Network {0} to Instance {1}." \
                                          "Raised Exception: {2} ".format(net_id,
-                                                                       action_resource_info.deployed_app_resource_name,
-                                                                       result_err_msg)
+                                                                         action_resource_info.deployed_app_resource_name,
+                                                                         result_err_msg)
             action_result.infoMessage = ""
             action_result.updatedInterface = ""
             action_result.type = 'setVlan'
@@ -334,9 +341,7 @@ class VLANConnectivityService(object):
             result = self.instance_service.detach_nic_from_instance(openstack_session=openstack_session,
                                                                     instance_id=vm_uuid, port_id=port_id, logger=logger)
         except Exception as e:
-            logger.error(e)
-            result_err_msg = "{0} {1}".format(type(e), e.message)
-            result_err_msg = result_err_msg.replace("<", "(").replace(">",")")
+            result_err_msg = self._format_err_msg_for_exception(e)
             logger.error(result_err_msg)
         if not result:
             action_result.success = "False"

--- a/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
@@ -45,8 +45,6 @@ class NeutronNetworkService(object):
         except NetCreateConflict:
             new_net = client.list_networks(**{'provider:segmentation_id':segmentation_id})
             new_net = new_net['networks'][0]
-        except Exception as e:
-            raise
 
         return new_net
 

--- a/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
@@ -46,8 +46,7 @@ class NeutronNetworkService(object):
             new_net = client.list_networks(**{'provider:segmentation_id':segmentation_id})
             new_net = new_net['networks'][0]
         except Exception as e:
-            logger.error(traceback.format_exc())
-            return None
+            raise
 
         return new_net
 
@@ -83,7 +82,7 @@ class NeutronNetworkService(object):
         cidr = self._get_unused_cidr(client=client, cp_resvd_cidrs=cp_resource_model.reserved_networks, logger=logger)
         if cidr is None:
             logger.error("Cannot allocate new subnet. All subnets exhausted")
-            return None
+            raise ValueError("All Subnets Exhausted")
 
         subnet_name = 'qs_subnet_' + net_id
         create_subnet_json = {'cidr': cidr,
@@ -92,12 +91,8 @@ class NeutronNetworkService(object):
                               'name': subnet_name,
                               'gateway_ip': None}
 
-        try:
-            new_subnet = client.create_subnet({'subnet':create_subnet_json})
-            new_subnet = new_subnet['subnet']
-        except Exception as e:
-            logger.error(traceback.format_exc())
-            return None
+        new_subnet = client.create_subnet({'subnet':create_subnet_json})
+        new_subnet = new_subnet['subnet']
 
         return new_subnet
 

--- a/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
@@ -125,21 +125,6 @@ class NovaInstanceService(object):
                 instance.stop()
                 self.instance_waiter.wait(instance, self.instance_waiter.SHUTOFF)
 
-    def get_security_groups(self, openstack_session, instance):
-        """
-        :param keystoneauth1.session.Session openstack_session:
-        :param novaclient.Client.servers.Server instance:
-        :rtype dict: Dictionary of Security Groups attached to instance.
-        """
-        pass
-
-    def get_interfaces(self, instance):
-        """
-        :param novaclient.Client.servers.Server instance:
-        :rtype dict: Dictionary of Interfaces attached (gives IP addrsses)
-        """
-        pass
-
     def get_instance_mgmt_network_name(self, instance, openstack_session, cp_resource_model):
         """
 

--- a/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
@@ -226,7 +226,8 @@ class NovaInstanceService(object):
             # result = "/".join([iface_ip, iface_portid, iface_mac])
             return result
         except Exception as e:
-            logger.info("Exception: {0} during interface attach".format(e))
+            logger.error("Exception: {0} during interface attach.".format(e))
+            raise
 
         return None
 

--- a/package/tests/test_cp/test_openstack/test_domain/test_services/test_connectivity/test_vlan_connectivity_service.py
+++ b/package/tests/test_cp/test_openstack/test_domain/test_services/test_connectivity/test_vlan_connectivity_service.py
@@ -48,9 +48,10 @@ class TestVlanConnectivityService(TestCase):
                                                              cp_resource_model=mock_cp_resource_model,
                                                              vlan_actions=test_vlan_actions,
                                                              logger=self.mock_logger)
+        failure_text = 'Failed to attach Subnet to Network test_net_id.Raised Exception: empty_subnet'
         self.connectivity_service.set_fail_results.assert_any_call(values='test_value',
                                                                    action_type='setVlan',
-                                                                   failure_text='Failed to attach Subnet to Network test_net_id')
+                                                                   failure_text=failure_text)
         assert self.connectivity_service.set_fail_results.call_count == 2
         self.assertTrue(results, ['fail_result', 'fail_result'])
 

--- a/package/tests/test_cp/test_openstack/test_domain/test_services/test_neutron/test_neutron_network_service.py
+++ b/package/tests/test_cp/test_openstack/test_domain/test_services/test_neutron/test_neutron_network_service.py
@@ -90,12 +90,13 @@ class TestNeutronNetworkService(TestCase):
         test_net_id = 'test-net-id'
         mock_client = Mock()
         test_neutron_network_service.neutron_client.Client = Mock(return_value=mock_client)
-        mock_client.create_subnet = Mock(return_value=None)
+        mock_client.create_subnet = Mock(side_effect=Exception)
 
         self.network_service._get_unused_cidr = Mock(return_value = '10.0.0.0/24')
 
-        result = self.network_service.create_and_attach_subnet_to_net(openstack_session=self.openstack_session,
+        with self.assertRaises(Exception) as context:
+            result = self.network_service.create_and_attach_subnet_to_net(openstack_session=self.openstack_session,
                                                                       cp_resource_model=Mock(),
                                                                       net_id=test_net_id,
                                                                       logger=self.mock_logger)
-        self.assertEqual(result, None)
+        self.assertTrue(context)

--- a/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
+++ b/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
@@ -112,6 +112,54 @@ class TestNovaInstanceService(TestCase):
                                                                                client=mock_client2)
         self.assertEqual(True, mock_instance.start.called)
 
+    def test_instance_power_on_no_instance(self):
+        """
+
+        :return:
+        """
+        mock_client2 = Mock()
+        test_nova_instance_service.novaclient.Client = Mock(return_value=mock_client2)
+
+        test_instance_id = 'test-id'
+        self.instance_service.get_instance_from_instance_id = Mock(return_value=None)
+
+        with self.assertRaises(ValueError) as context:
+            self.instance_service.instance_power_on(openstack_session=self.openstack_session,
+                                                    instance_id=test_instance_id,
+                                                    logger=self.mock_logger)
+
+        self.instance_service.get_instance_from_instance_id.assert_called_with(
+                openstack_session=self.openstack_session,
+                instance_id=test_instance_id,
+                logger=self.mock_logger,
+                client=mock_client2)
+
+        self.assertTrue(context)
+
+    def test_instance_power_off_no_instance(self):
+        """
+
+        :return:
+        """
+        mock_client2 = Mock()
+        test_nova_instance_service.novaclient.Client = Mock(return_value=mock_client2)
+
+        test_instance_id = 'test-id'
+        self.instance_service.get_instance_from_instance_id = Mock(return_value=None)
+
+        with self.assertRaises(ValueError) as context:
+            self.instance_service.instance_power_off(openstack_session=self.openstack_session,
+                                                    instance_id=test_instance_id,
+                                                    logger=self.mock_logger)
+
+        self.instance_service.get_instance_from_instance_id.assert_called_with(
+                openstack_session=self.openstack_session,
+                instance_id=test_instance_id,
+                logger=self.mock_logger,
+                client=mock_client2)
+
+        self.assertTrue(context)
+
     def test_get_instance_from_instance_id(self):
         mock_client2 = Mock()
         test_nova_instance_service.novaclient.Client = Mock(return_value=mock_client2)
@@ -294,3 +342,44 @@ class TestNovaInstanceService(TestCase):
         self.instance_service.delete_floating_ip(openstack_session=self.openstack_session,
                                                  floating_ip=mock_floating_ip_obj.ip)
         mock_client.floating_ips.delete.assert_called_with(mock_floating_ip_obj.id)
+
+    def test_get_instance_mgmt_net_name_success(self):
+        mock_client = Mock()
+        test_nova_instance_service.novaclient.Client = Mock(return_value=mock_client)
+
+        test_net_id = 'test_net_id'
+        test_cp_resource_model = Mock()
+        test_cp_resource_model.qs_mgmt_os_net_uuid = test_net_id
+
+        mock_net_obj = Mock()
+        mock_net_obj.to_dict = Mock(return_value={'id':test_net_id, 'label':'test_returned_net'})
+
+        mock_client.networks = Mock()
+        mock_client.networks.list = Mock(return_value=[mock_net_obj])
+
+        result = self.instance_service.get_instance_mgmt_network_name(instance=Mock(),
+                                                                      openstack_session=self.openstack_session,
+                                                                      cp_resource_model=test_cp_resource_model)
+
+        self.assertEqual(result, 'test_returned_net')
+
+    def test_get_instance_mgmt_net_name_fail(self):
+        mock_client = Mock()
+        test_nova_instance_service.novaclient.Client = Mock(return_value=mock_client)
+
+        test_net_id = 'test_net_id'
+        test_cp_resource_model = Mock()
+        test_cp_resource_model.qs_mgmt_os_net_uuid = test_net_id
+
+        test_net_id_1 = 'test_net_id_1'
+        mock_net_obj = Mock()
+        mock_net_obj.to_dict = Mock(return_value={'id': test_net_id_1, 'label': 'test_returned_net'})
+
+        mock_client.networks = Mock()
+        mock_client.networks.list = Mock(return_value=[mock_net_obj])
+
+        result = self.instance_service.get_instance_mgmt_network_name(instance=Mock(),
+                                                                      openstack_session=self.openstack_session,
+                                                                      cp_resource_model=test_cp_resource_model)
+
+        self.assertEqual(result, None)

--- a/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
+++ b/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
@@ -210,12 +210,13 @@ class TestNovaInstanceService(TestCase):
 
         mock_instance.interface_attach = Mock(side_effect=Exception)
 
-        result = self.instance_service.attach_nic_to_net(openstack_session=self.openstack_session,
+        with self.assertRaises(Exception) as context:
+            result = self.instance_service.attach_nic_to_net(openstack_session=self.openstack_session,
                                                          net_id='test_net_id',
                                                          instance_id='test_instance_id',
                                                          logger=self.mock_logger)
 
-        self.assertEqual(result, None)
+        self.assertTrue(context)
 
     def test_detach_nic_from_net_success(self):
 


### PR DESCRIPTION
 Nova error messages raise exceptions during deploy (etc).
 Neutron error messages are reported as errorMessage in connectivityResult

## Description

Fixed error reporting during deploy and connectivity. Right errors are now reported to user

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/131)
<!-- Reviewable:end -->
