### PR TITLE
 #144 - Regression introduced in power-on/off after cancellation context

### DIFF
--- a/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/nova/nova_instance_service.py
@@ -113,7 +113,8 @@ class NovaInstanceService(object):
 
             if instance.status != self.instance_waiter.ACTIVE:
                 instance.start()
-                self.instance_waiter.wait(instance, self.instance_waiter.ACTIVE)
+                self.instance_waiter.wait(instance=instance, state=self.instance_waiter.ACTIVE,
+                                          cancellation_context=None, logger=logger)
 
     def instance_power_off(self, openstack_session, instance_id, logger):
         """
@@ -136,7 +137,8 @@ class NovaInstanceService(object):
         else:
             if instance.status != self.instance_waiter.SHUTOFF:
                 instance.stop()
-                self.instance_waiter.wait(instance, self.instance_waiter.SHUTOFF)
+                self.instance_waiter.wait(instance=instance, state=self.instance_waiter.SHUTOFF,
+                                          cancellation_context=None, logger=logger)
 
     def get_instance_mgmt_network_name(self, instance, openstack_session, cp_resource_model):
         """

--- a/package/cloudshell/cp/openstack/domain/services/waiters/instance.py
+++ b/package/cloudshell/cp/openstack/domain/services/waiters/instance.py
@@ -48,7 +48,8 @@ class InstanceWaiter(object):
 
         while instance.status != state:
             instance.get()
-            self.cancellation_service.check_if_cancelled(cancellation_context=cancellation_context)
+            if cancellation_context is not None:
+                self.cancellation_service.check_if_cancelled(cancellation_context=cancellation_context)
             time.sleep(self.delay)
 
         return instance

--- a/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
+++ b/package/tests/test_cp/test_openstack/test_domain/test_services/test_nova/test_nova_instance_service.py
@@ -150,7 +150,6 @@ class TestNovaInstanceService(TestCase):
                                                                       cancellation_context=mock_cancellation_context,
                                                                       logger=self.mock_logger)
 
-
     def test_instance_terminate_openstack_session_none(self):
         with self.assertRaises(ValueError) as context:
             self.instance_service.terminate_instance(openstack_session=None,
@@ -193,6 +192,10 @@ class TestNovaInstanceService(TestCase):
                                                                                instance_id=test_instance_id,
                                                                                logger=self.mock_logger,
                                                                                client=mock_client2)
+        self.instance_service.instance_waiter.wait.assert_called_with(instance=mock_instance,
+                                                                      state=self.instance_service.instance_waiter.SHUTOFF,
+                                                                      cancellation_context=None,
+                                                                      logger=self.mock_logger)
         self.assertEqual(True, mock_instance.stop.called)
 
     def test_instance_power_on_success(self):
@@ -210,6 +213,10 @@ class TestNovaInstanceService(TestCase):
                                                                                instance_id=test_instance_id,
                                                                                logger=self.mock_logger,
                                                                                client=mock_client2)
+        self.instance_service.instance_waiter.wait.assert_called_with(instance=mock_instance,
+                                                                      state=self.instance_service.instance_waiter.ACTIVE,
+                                                                      cancellation_context=None,
+                                                                      logger=self.mock_logger)
         self.assertEqual(True, mock_instance.start.called)
 
     def test_instance_power_on_no_instance(self):


### PR DESCRIPTION
We were not passing cancellation_context to wait method called during power-on/off operations

## Description
Fix for 144

## Related Stories
List related PRs against other branches:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/145)
<!-- Reviewable:end -->
