### PR TITLE
 #201 Fix

### DIFF
--- a/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
+++ b/package/cloudshell/cp/openstack/domain/services/neutron/neutron_network_service.py
@@ -160,7 +160,8 @@ class NeutronNetworkService(object):
         # currently supports /24 subnets
         logger.debug("reserved CIDRs: {0}".format(cp_resvd_cidrs))
 
-        blacklist_cidrs = map(lambda x: x.strip(), cp_resvd_cidrs.split(","))
+        # Empty reserved_addresses generates a list with single empty string
+        blacklist_cidrs = filter(lambda x: len(x) > 0, map(lambda x: x.strip(), cp_resvd_cidrs.split(",")))
 
         current_subnets = client.list_subnets(fields=['cidr', 'id'])['subnets']
         current_subnets_cidrs = map(lambda x: unicode(x.get('cidr')), current_subnets)


### PR DESCRIPTION
 Fixed if optional reserved_networks parameter was left empty

## Description

Reserved network string can now be empty

## Breaking
NO


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/203)
<!-- Reviewable:end -->
