### PR TITLE
 #209 Fix

### DIFF
--- a/package/cloudshell/cp/openstack/domain/services/nova/udev_rules.py
+++ b/package/cloudshell/cp/openstack/domain/services/nova/udev_rules.py
@@ -46,4 +46,6 @@ logger -i -s --tag $LOGGER_TAG  "Calling udevadm control"
 logger -i -s --tag $LOGGER_TAG "Rebooting for the rules to take effect!"
 shutdown -r
 
+
+
 '''

--- a/package/cloudshell/cp/openstack/domain/services/nova/udev_rules.py
+++ b/package/cloudshell/cp/openstack/domain/services/nova/udev_rules.py
@@ -41,4 +41,9 @@ logger -i -s --tag $LOGGER_TAG "Disabling device name change."
 logger -i -s --tag $LOGGER_TAG  "Calling udevadm control"
 /sbin/udevadm control --reload && /sbin/udevadm trigger --subsystem-match=net
 
+## Rebooting
+
+logger -i -s --tag $LOGGER_TAG "Rebooting for the rules to take effect!"
+shutdown -r
+
 '''


### PR DESCRIPTION
 Fix for Ubuntu not activating the udev rules. We initiate a reboot at the
 end of applying udev rules.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Stories
#159 

## Breaking
 NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/openstack-shell/211)
<!-- Reviewable:end -->
